### PR TITLE
Fix: Resolve assignment overfetching on course page

### DIFF
--- a/app/course/[id]/page.tsx
+++ b/app/course/[id]/page.tsx
@@ -18,7 +18,8 @@ import {
 import {
   fetchAssignmentsByVideo,
   fetchAssignmentStatus,
-  selectAssignments
+  selectAssignments,
+  fetchAssignmentsByCourse // Added import
 } from '@/store/slices/assignmentSlice';
 
 export default function Page({ params }: { params: { id: string } }) {
@@ -107,10 +108,8 @@ export default function Page({ params }: { params: { id: string } }) {
     // Find assignments for this video and fetch their status
     const videoAssignments = findAssignmentsForVideo(videoId);
     if (videoAssignments.length > 0) {
-      // Fetch assignments for this video
-      dispatch(fetchAssignmentsByVideo(videoId));
-      
       // Fetch status for each assignment
+      // dispatch(fetchAssignmentsByVideo(videoId)); // Removed redundant dispatch
       videoAssignments.forEach(assignment => {
         dispatch(fetchAssignmentStatus(assignment.id));
       });
@@ -181,10 +180,8 @@ export default function Page({ params }: { params: { id: string } }) {
           });
           setOpenVideoIds(initialOpenState);
           
-          // Fetch assignments for all videos in the course immediately after getting course data
-          data.videos.forEach((video: any) => {
-            dispatch(fetchAssignmentsByVideo(video.id));
-          });
+          // Fetch all assignments for the course
+          dispatch(fetchAssignmentsByCourse({ courseId: params.id, videoIds: data.videos.map((video: any) => video.id) }));
         }
         
         // Check if user is already enrolled in this course


### PR DESCRIPTION
Previously, the course page component fetched assignments for each video individually and then potentially re-fetched them when checking video status. This resulted in multiple redundant API calls, especially for courses with many videos.

This commit introduces the following changes:

1.  **New `fetchAssignmentsByCourse` Thunk:** Added an async thunk `fetchAssignmentsByCourse` to `assignmentSlice.ts`. This thunk takes a course ID and a list of video IDs for that course. It iterates through the video IDs, calls the existing `fetchAssignmentsByVideo` endpoint for each, and aggregates all assignments into a single list in the Redux store. This centralizes the fetching of all assignments for a course into one logical operation.

2.  **Updated Course Page Component (`app/course/[id]/page.tsx`):**
    - Modified the component to dispatch `fetchAssignmentsByCourse` once after the main course data (including the list of videos) is loaded.
    - Removed the initial loop that was dispatching `fetchAssignmentsByVideo` for every video.
    - Removed the redundant `dispatch(fetchAssignmentsByVideo(videoId))` call from the `checkVideoAndQuizStatus` function.

These changes ensure that the list of assignments for all videos in a course is fetched only once when the course page loads, significantly reducing the number of API requests and improving performance. Individual assignment statuses are still fetched as needed when video details are expanded.